### PR TITLE
Always print banner before verifyToken

### DIFF
--- a/packages/onlineornot/src/checks/create.ts
+++ b/packages/onlineornot/src/checks/create.ts
@@ -30,10 +30,10 @@ export function options(yargs: CommonYargsArgv) {
 export async function handler(
 	args: StrictYargsOptionsToInterface<typeof options>
 ) {
-	await verifyToken();
 	if (!args.json) {
 		await printBanner();
 	}
+	await verifyToken();
 	let result: Check;
 	try {
 		result = await fetchResult(`/checks/`, {

--- a/packages/onlineornot/src/checks/individualCheck.ts
+++ b/packages/onlineornot/src/checks/individualCheck.ts
@@ -25,10 +25,10 @@ export function options(yargs: CommonYargsArgv) {
 export async function handler(
 	args: StrictYargsOptionsToInterface<typeof options>
 ) {
-	await verifyToken();
 	if (!args.json) {
 		await printBanner();
 	}
+	await verifyToken();
 	const result = (await fetchResult(`/checks/${args.id}`)) as Check;
 
 	if (args.json) {

--- a/packages/onlineornot/src/checks/list.ts
+++ b/packages/onlineornot/src/checks/list.ts
@@ -19,10 +19,10 @@ export function options(yargs: CommonYargsArgv) {
 export async function handler(
 	args: StrictYargsOptionsToInterface<typeof options>
 ) {
-	await verifyToken();
 	if (!args.json) {
 		await printBanner();
 	}
+	await verifyToken();
 	const results = (await fetchPagedResult("/checks")) as Check[];
 
 	if (args.json) {


### PR DESCRIPTION
`onlineornot checks delete` followed this order already.

Previously, the user wouldn't see the banner if they had any errors.