### PR TITLE
Publish GitHub releases for the API SDK

### DIFF
--- a/.github/find-package-version-commit.mjs
+++ b/.github/find-package-version-commit.mjs
@@ -1,0 +1,48 @@
+import { execFileSync } from "node:child_process";
+
+function git(args) {
+	return execFileSync("git", args, { encoding: "utf8" }).trim();
+}
+
+function versionAtCommit(commit, packageJsonPath) {
+	try {
+		return JSON.parse(git(["show", `${commit}:${packageJsonPath}`])).version;
+	} catch {
+		return undefined;
+	}
+}
+
+export function findPackageVersionCommit(packageJsonPath, expectedVersion) {
+	const commits = git(["log", "--format=%H", "--", packageJsonPath])
+		.split("\n")
+		.filter(Boolean);
+
+	for (const commit of commits) {
+		if (versionAtCommit(commit, packageJsonPath) !== expectedVersion) continue;
+
+		const [, firstParent] = git([
+			"rev-list",
+			"--parents",
+			"-n",
+			"1",
+			commit,
+		]).split(" ");
+		if (
+			!firstParent ||
+			versionAtCommit(firstParent, packageJsonPath) !== expectedVersion
+		) {
+			return commit;
+		}
+	}
+
+	throw new Error(
+		`Could not find the commit that set ${packageJsonPath} to ${expectedVersion}`,
+	);
+}
+
+if (
+	process.argv[1] &&
+	import.meta.url === new URL(process.argv[1], "file:").href
+) {
+	console.log(findPackageVersionCommit(process.argv[2], process.argv[3]));
+}

--- a/.github/package-release-published.mjs
+++ b/.github/package-release-published.mjs
@@ -1,4 +1,8 @@
-export function wasCliPublished(publishedPackages, expectedVersion) {
+export function wasPackagePublished(
+	publishedPackages,
+	packageName,
+	expectedVersion,
+) {
 	if (!publishedPackages) return false;
 	let packages;
 	try {
@@ -9,8 +13,7 @@ export function wasCliPublished(publishedPackages, expectedVersion) {
 	if (!Array.isArray(packages))
 		throw new Error("changesets publishedPackages was not an array");
 	return packages.some(
-		(entry) =>
-			entry?.name === "onlineornot" && entry.version === expectedVersion,
+		(entry) => entry?.name === packageName && entry.version === expectedVersion,
 	);
 }
 
@@ -18,5 +21,7 @@ if (
 	process.argv[1] &&
 	import.meta.url === new URL(process.argv[1], "file:").href
 ) {
-	console.log(wasCliPublished(process.argv[2], process.argv[3]));
+	console.log(
+		wasPackagePublished(process.argv[2], process.argv[3], process.argv[4]),
+	);
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
           TAG="onlineornot@$VERSION"
           PACKAGE_EXISTS=false
           NPM_LATEST=""
-          CLI_JUST_PUBLISHED=$(node .github/cli-release-published.mjs "$PUBLISHED_PACKAGES" "$VERSION")
+          CLI_JUST_PUBLISHED=$(node .github/package-release-published.mjs "$PUBLISHED_PACKAGES" "onlineornot" "$VERSION")
           if [[ "$CLI_JUST_PUBLISHED" == "true" ]]; then
             PACKAGE_EXISTS=true
             NPM_LATEST="$VERSION"
@@ -102,6 +102,58 @@ jobs:
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "release_pending=$RELEASE_PENDING" >> "$GITHUB_OUTPUT"
+
+      - name: Inspect pending API SDK release
+        id: inspect-api-release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
+        run: |
+          VERSION=$(node -p 'require("./packages/api/package.json").version')
+          TAG="@onlineornot/api@$VERSION"
+          PACKAGE_EXISTS=false
+          NPM_LATEST=""
+          API_JUST_PUBLISHED=$(node .github/package-release-published.mjs "$PUBLISHED_PACKAGES" "@onlineornot/api" "$VERSION")
+          if [[ "$API_JUST_PUBLISHED" == "true" ]]; then
+            PACKAGE_EXISTS=true
+            NPM_LATEST="$VERSION"
+          elif PUBLISHED_VERSION=$(npm view "@onlineornot/api@$VERSION" version 2>/dev/null); then
+            if [[ "$PUBLISHED_VERSION" == "$VERSION" ]]; then
+              PACKAGE_EXISTS=true
+              NPM_LATEST=$(npm view @onlineornot/api dist-tags.latest)
+            fi
+          fi
+          RELEASE_EXISTS=$(gh api --paginate "repos/$GITHUB_REPOSITORY/releases?per_page=100" \
+            --jq ".[] | select(.tag_name == \"$TAG\" and .draft == false) | .tag_name")
+          RELEASE_PENDING=false
+          if [[ "$PACKAGE_EXISTS" == "true" && "$NPM_LATEST" == "$VERSION" && -z "$RELEASE_EXISTS" ]]; then
+            RELEASE_PENDING=true
+          fi
+          if [[ "$RELEASE_PENDING" == "true" ]]; then
+            if ! git rev-parse --verify "refs/tags/$TAG" >/dev/null 2>&1; then
+              if [[ "$API_JUST_PUBLISHED" == "true" ]]; then
+                RELEASE_COMMIT="$GITHUB_SHA"
+              else
+                RELEASE_COMMIT=$(node .github/find-package-version-commit.mjs packages/api/package.json "$VERSION")
+              fi
+              git tag "$TAG" "$RELEASE_COMMIT"
+              git push origin "refs/tags/$TAG"
+            fi
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "release_pending=$RELEASE_PENDING" >> "$GITHUB_OUTPUT"
+
+      - name: Publish API SDK GitHub release
+        if: steps.inspect-api-release.outputs.release_pending == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.inspect-api-release.outputs.version }}
+        run: |
+          TAG="@onlineornot/api@$VERSION"
+          node -r esbuild-register packages/onlineornot/scripts/extract-release-notes.ts \
+            "$VERSION" packages/api/CHANGELOG.md api-release-notes.md
+          gh release create "$TAG" --verify-tag --title "$TAG" \
+            --notes-file api-release-notes.md --latest=false
 
     outputs:
       release_pending: ${{ steps.inspect-release.outputs.release_pending }}

--- a/packages/api/test/release-workflow.test.ts
+++ b/packages/api/test/release-workflow.test.ts
@@ -4,14 +4,15 @@ import { fileURLToPath } from "node:url";
 
 import { expect, it } from "vitest";
 
-import { wasCliPublished } from "../../../.github/cli-release-published.mjs";
+import { wasPackagePublished } from "../../../.github/package-release-published.mjs";
 
 it("does not treat an API-only Changesets publication as a CLI release", () => {
+	const publishedPackages = '[{"name":"@onlineornot/api","version":"0.1.0"}]';
+	expect(wasPackagePublished(publishedPackages, "onlineornot", "1.6.5")).toBe(
+		false,
+	);
 	expect(
-		wasCliPublished('[{"name":"@onlineornot/api","version":"0.1.0"}]', "1.6.5"),
-	).toBe(false);
-	expect(
-		wasCliPublished('[{"name":"onlineornot","version":"1.6.6"}]', "1.6.6"),
+		wasPackagePublished(publishedPackages, "@onlineornot/api", "0.1.0"),
 	).toBe(true);
 });
 
@@ -24,4 +25,17 @@ it("includes both packages in preview publishing", () => {
 		"utf8",
 	);
 	expect(workflow).toContain("'./packages/onlineornot' './packages/api'");
+});
+
+it("publishes API SDK GitHub releases without replacing the CLI latest release", () => {
+	const root = path.resolve(
+		fileURLToPath(new URL("../../..", import.meta.url)),
+	);
+	const workflow = readFileSync(
+		path.join(root, ".github/workflows/release.yml"),
+		"utf8",
+	);
+	expect(workflow).toContain('TAG="@onlineornot/api@$VERSION"');
+	expect(workflow).toContain('gh release create "$TAG" --verify-tag');
+	expect(workflow).toContain("--latest=false");
 });


### PR DESCRIPTION
## Summary

- publish a GitHub release tagged `@onlineornot/api@<version>` after an API SDK version is published to npm
- generate release notes from the API changelog while keeping CLI binary releases marked as the repository's latest release
- recover missing API releases on later workflow runs, tagging the commit that originally introduced the published package version
- generalize Changesets publication detection so the CLI and API release paths remain isolated
- add workflow coverage for API-only publications and API GitHub release behavior

The recovery path will also backfill the existing `@onlineornot/api@0.1.0` release when this reaches `main`, using the original version commit rather than the newer workflow commit.

## Verification

- `pnpm run build`
- `pnpm run check`
- `pnpm run test:ci` (59 tests passed)
- validated `.github/workflows/release.yml` as YAML
- verified the recovery helper resolves `@onlineornot/api@0.1.0` to `63b2925`
